### PR TITLE
[FEAT] 랜딩 positioin 섹션 구현

### DIFF
--- a/src/components/features/Home/ActivitySection.tsx
+++ b/src/components/features/Home/ActivitySection.tsx
@@ -24,45 +24,43 @@ export const ActivitySection = () => {
     (activity) => activity.title === selectedActivity
   );
   return (
-    <section className="min-h-screen bg-bg-gray flex items-center justify-center px-4 md:px-35">
-      <div className="container mx-auto">
-        <div className="=max-w-8xl mx-auto lg:ml-40 md:ml-20">
-          <div className="grid grid-cols-1 md:grid-cols-10 gap-6 md:gap-8 items-center md:items-start">
-            {/* 왼쪽: 이미지*/}
-            <div className="relative w-full aspect-[16/9] rounded-lg overflow-hidden md:col-span-7">
-              {activities.map((activity) => (
-                <Image
-                  key={activity.title}
-                  src={activity.imagePath}
-                  alt={activity.title}
-                  fill
-                  className={`object-cover transition-opacity duration-300 ${
-                    selectedActivity === activity.title
-                      ? "opacity-100"
-                      : "opacity-0"
-                  }`}
-                  priority
-                />
-              ))}
-            </div>
+    <section className="min-h-screen flex items-center justify-center">
+      <div className="w-full max-w-4xl mx-auto px-4">
+        <div className="grid grid-cols-1 md:grid-cols-10 gap-6 md:gap-8 items-center md:items-start">
+          {/* 왼쪽: 이미지*/}
+          <div className="relative w-full aspect-[16/9] rounded-lg overflow-hidden md:col-span-8">
+            {activities.map((activity) => (
+              <Image
+                key={activity.title}
+                src={activity.imagePath}
+                alt={activity.title}
+                fill
+                className={`object-cover transition-opacity duration-300 ${
+                  selectedActivity === activity.title
+                    ? "opacity-100"
+                    : "opacity-0"
+                }`}
+                priority
+              />
+            ))}
+          </div>
 
-            {/* 오른쪽: 카테고리 탭 */}
-            <div className="flex flex-col gap-3 md:col-span-3 text-xl md:text-xl lg:text-2xl">
-              {activities.map((activity) => (
-                <button
-                  key={activity.title}
-                  onClick={() => setSelectedActivity(activity.title)}
-                  className={`pl-2 pb-3 text-center md:text-left transition-all duration-200 cursor-pointer ${
-                    selectedActivity === activity.title
-                      ? "text-foreground"
-                      : "text-text-gray-light hover:text-foreground"
-                  }
+          {/* 오른쪽: 카테고리 탭 */}
+          <div className="flex flex-col items-center md:items-start gap-3 md:col-span-2 text-xl md:text-xl lg:text-2xl">
+            {activities.map((activity) => (
+              <button
+                key={activity.title}
+                onClick={() => setSelectedActivity(activity.title)}
+                className={`w-fit pl-2 pb-3 text-center md:text-left transition-all duration-200 cursor-pointer ${
+                  selectedActivity === activity.title
+                    ? "text-foreground"
+                    : "text-text-gray-light hover:text-foreground"
+                }
             `}
-                >
-                  {activity.title}
-                </button>
-              ))}
-            </div>
+              >
+                {activity.title}
+              </button>
+            ))}
           </div>
         </div>
       </div>

--- a/src/components/features/Home/Home.tsx
+++ b/src/components/features/Home/Home.tsx
@@ -2,6 +2,7 @@ import { Header } from "@/components/layout/Header/Header";
 import { HeroSection } from "@/components/features/Home/HeroSection";
 import { IntroductionSection } from "@/components/features/Home/IntroductionSection";
 import { ActivitySection } from "@/components/features/Home/ActivitySection";
+import { PositionSection } from "@/components/features/Home/PositionSection";
 
 export const Home = () => {
   return (
@@ -11,6 +12,7 @@ export const Home = () => {
         <HeroSection />
         <IntroductionSection />
         <ActivitySection />
+        <PositionSection />
       </main>
     </>
   );

--- a/src/components/features/Home/PositionSection.tsx
+++ b/src/components/features/Home/PositionSection.tsx
@@ -1,0 +1,44 @@
+import Card from "@/components/features/Home/components/Card";
+
+const positions = [
+  {
+    title: "PO",
+    description:
+      "교차기능팀에서 해결하고자 하는 문제를 분석하고, 사용자 관점에서 최적의 솔루션을 도출하는 방법을 연습합니다.",
+  },
+  {
+    title: "PD",
+    description:
+      "사용자 중심의 프로덕트 디자인을 이해하고, 다른 직군과 함께 일하는 협업 프로세스를 배웁니다.",
+  },
+  {
+    title: "Frontend",
+    description:
+      "사용자와 가장 가까운 화면을 만드는 역할로, React.js를 활용해 직관적이고 매력적인 웹 경험을 구현합니다. 논리적 사고와 UI 구현 감각을 함께 발전시킵니다.",
+  },
+  {
+    title: "Android",
+    description:
+      "안드로이드 직군은 모바일 환경에서 직접 실행되는 앱을 개발합니다. Kotlin과 Android Studio를 사용해 화면 구현부터 서버 연동까지 앱 개발 전반을 실습하며, 실무에 필요한 개발 감각과 노하우를 함께 익힙니다.",
+  },
+  {
+    title: "Backend",
+    description:
+      "서버와 데이터베이스를 중심으로, 서비스의 비즈니스 로직을 설계하고 구현합니다. 사용자의 요청이 어떻게 처리되고, 데이터를 어떻게 관리 및 보호해야 하는지 이해하며, 안정적이고 확장 가능한 서버를 구성하기 위한 과정을 배웁니다.",
+  },
+  {
+    title: "Game",
+    description:
+      "게임을 만드는 데 필요한 핵심 개념을 익히고, 여러 직군과 협업하여 실제로 게임을 만들어봅니다.",
+  },
+];
+
+export const PositionSection = () => {
+  return (
+    <section className="w-full max-w-4xl mx-auto space-y-2 py-7 px-2 mb-30">
+      {positions.map((p) => (
+        <Card key={p.title} title={p.title} description={p.description} />
+      ))}
+    </section>
+  );
+};

--- a/src/components/features/Home/components/Card.tsx
+++ b/src/components/features/Home/components/Card.tsx
@@ -1,0 +1,15 @@
+type CardProps = {
+  title: string;
+  description: string;
+};
+
+export default function Card({ title, description }: CardProps) {
+  return (
+    <div className="w-full rounded-xl bg-[#F2F6F9] p-5">
+      <h3 className="text-xl font-bold text-text-foreground">{title}</h3>
+      <p className="mt-2 text-sm text-text-gray-dark leading-relaxed">
+        {description}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
# 변경점 👍
- 랜딩 페이지의 position 섹션을 구현하였습니다.
- 반응형을 구현하였습니다.

# 스크린샷 🖼

 
<img width="969" height="741" alt="스크린샷 2025-11-24 오후 3 46 43" src="https://github.com/user-attachments/assets/935f131b-f340-4a92-b4c6-4364f32084ed" />

<img width="377" height="690" alt="스크린샷 2025-11-24 오후 3 47 09" src="https://github.com/user-attachments/assets/8cea382a-af0a-4bba-852b-4992d5596adc" />
