### PR TITLE
[STYLE] 소개 페이지 인터렉션 구현 및 소개 페이지 폰트 일부 변경

### DIFF
--- a/src/components/features/About/AboutActivitySection.tsx
+++ b/src/components/features/About/AboutActivitySection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 
 interface ActivityItem {
@@ -29,14 +30,36 @@ const activities: ActivityItem[] = [
 ];
 
 export const AboutActivitySection = () => {
+  const sectionRef = useRef<HTMLElement>(null);
+  const [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    const target = sectionRef.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsInView(entry.isIntersecting);
+      },
+      { threshold: 0, rootMargin: "-45% 0px -45% 0px" },
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <section className="bg-white py-16 md:py-24">
+    <section ref={sectionRef} className="bg-white py-16 md:py-24">
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
           {/* 상단 라벨 */}
           <p
-            className="text-text-secondary text-sm uppercase"
-            style={{ fontFamily: "var(--font-suit), SUIT, sans-serif" }}
+            className="text-text-secondary text-sm uppercase font-extrabold"
+            style={{
+              fontFamily: "var(--font-suit), SUIT, sans-serif",
+              color: isInView ? "#FF7C0A" : undefined,
+              transition: "color 300ms ease",
+            }}
           >
             ACTIVITY
           </p>
@@ -47,7 +70,7 @@ export const AboutActivitySection = () => {
               <h2
                 className="text-2xl md:text-3xl lg:text-4xl font-bold !mb-1 md:!mb-2 lg:!mb-3"
                 style={{
-                  fontFamily: "var(--font-pretendard), Pretendard, sans-serif",
+                  fontFamily: "var(--font-suit), SUIT, sans-serif",
                   color: "#0F1012",
                 }}
               >
@@ -56,7 +79,7 @@ export const AboutActivitySection = () => {
               <p
                 className="text-base md:text-base"
                 style={{
-                  fontFamily: "var(--font-pretendard), Pretendard, sans-serif",
+                  fontFamily: "var(--font-suit), SUIT, sans-serif",
                   color: "#282A2E",
                 }}
               >
@@ -85,8 +108,7 @@ export const AboutActivitySection = () => {
                     <h3
                       className="text-xl md:text-2xl font-bold text-foreground mb-2"
                       style={{
-                        fontFamily:
-                          "var(--font-pretendard), Pretendard, sans-serif",
+                        fontFamily: "var(--font-suit), SUIT, sans-serif",
                       }}
                     >
                       {activity.title}
@@ -94,8 +116,7 @@ export const AboutActivitySection = () => {
                     <p
                       className="text-text-secondary text-base md:text-lg font-medium"
                       style={{
-                        fontFamily:
-                          "var(--font-pretendard), Pretendard, sans-serif",
+                        fontFamily: "var(--font-suit), SUIT, sans-serif",
                       }}
                     >
                       {activity.description}

--- a/src/components/features/About/AboutCurriculumSection.tsx
+++ b/src/components/features/About/AboutCurriculumSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type Position =
   | "기획"
@@ -41,9 +41,11 @@ const curriculumData: Record<Position, CurriculumItem[]> = {
     { title: "실전 적용 - 실습 및 과제, UI 설계 및 구현, 실전 감각 배양" },
   ],
   안드로이드: [
-    { title: "안드로이드 커리큘럼 항목 1" },
-    { title: "안드로이드 커리큘럼 항목 2" },
-    { title: "안드로이드 커리큘럼 항목 3" },
+    { title: "Kotlin 기본 문법과 앱 구조 이해" },
+    { title: "Jetpack Compose를 활용한 UI 설계 및 상태 관리" },
+    { title: "Retrofit, Coroutine을 이용한 서버 통신과 데이터 처리" },
+    { title: "MVVM 아키텍처로 효율적인 코드 구조 학습" },
+    { title: "실제 서비스 기능 구현과 앱 배포 프로세스 경험" },
   ],
   백엔드: [
     {
@@ -89,16 +91,37 @@ const positions: Position[] = [
 
 export const AboutCurriculumSection = () => {
   const [selectedPosition, setSelectedPosition] = useState<Position>("기획");
+  const sectionRef = useRef<HTMLElement>(null);
+  const [isInView, setIsInView] = useState(false);
   const currentCurriculum = curriculumData[selectedPosition];
 
+  useEffect(() => {
+    const target = sectionRef.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsInView(entry.isIntersecting);
+      },
+      { threshold: 0, rootMargin: "-45% 0px -45% 0px" },
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <section className="bg-white py-16 md:py-24">
+    <section ref={sectionRef} className="bg-white py-16 md:py-24">
       <div className="container mx-auto px-4">
         <div className="max-w-6xl mx-auto">
           {/* 상단 라벨 */}
           <p
-            className="text-text-secondary text-sm uppercase"
-            style={{ fontFamily: "var(--font-suit), SUIT, sans-serif" }}
+            className="text-text-secondary text-sm uppercase font-extrabold"
+            style={{
+              fontFamily: "var(--font-suit), SUIT, sans-serif",
+              color: isInView ? "#FF7C0A" : undefined,
+              transition: "color 300ms ease",
+            }}
           >
             CURRICULUM
           </p>
@@ -110,7 +133,7 @@ export const AboutCurriculumSection = () => {
               <h2
                 className="text-2xl md:text-3xl lg:text-4xl font-bold !mb-1 md:!mb-2 lg:!mb-3"
                 style={{
-                  fontFamily: "var(--font-pretendard), Pretendard, sans-serif",
+                  fontFamily: "var(--font-suit), SUIT, sans-serif",
                   color: "#0F1012",
                 }}
               >
@@ -119,7 +142,7 @@ export const AboutCurriculumSection = () => {
               <p
                 className="text-base md:text-base"
                 style={{
-                  fontFamily: "var(--font-pretendard), Pretendard, sans-serif",
+                  fontFamily: "var(--font-suit), SUIT, sans-serif",
                   color: "#282A2E",
                 }}
               >
@@ -144,8 +167,7 @@ export const AboutCurriculumSection = () => {
                           : "bg-white text-text-secondary "
                       }`}
                       style={{
-                        fontFamily:
-                          "var(--font-pretendard), Pretendard, sans-serif",
+                        fontFamily: "var(--font-suit), SUIT, sans-serif",
                       }}
                     >
                       {position}
@@ -164,8 +186,7 @@ export const AboutCurriculumSection = () => {
                           : "bg-white text-text-secondary "
                       }`}
                       style={{
-                        fontFamily:
-                          "var(--font-pretendard), Pretendard, sans-serif",
+                        fontFamily: "var(--font-suit), SUIT, sans-serif",
                       }}
                     >
                       {position}
@@ -186,10 +207,9 @@ export const AboutCurriculumSection = () => {
                 }}
               >
                 <p
-                  className="text-sm md:text-base lg:text-lg font-medium"
+                  className="text-sm md:text-base lg:text-lg font-semibold"
                   style={{
-                    fontFamily:
-                      "var(--font-pretendard), Pretendard, sans-serif",
+                    fontFamily: "var(--font-suit), SUIT, sans-serif",
                     color: "#0F1012",
                   }}
                 >
@@ -211,8 +231,7 @@ export const AboutCurriculumSection = () => {
                 <p
                   className="text-sm font-medium"
                   style={{
-                    fontFamily:
-                      "var(--font-pretendard), Pretendard, sans-serif",
+                    fontFamily: "var(--font-suit), SUIT, sans-serif",
                     color: "#0F1012",
                   }}
                 >

--- a/src/components/features/About/AboutHistorySection.tsx
+++ b/src/components/features/About/AboutHistorySection.tsx
@@ -257,7 +257,7 @@ const years = historyData.map((data) => data.year);
 export const AboutHistorySection = () => {
   const [selectedYear, setSelectedYear] = useState<number>(2025);
   const currentYearData = historyData.find(
-    (data) => data.year === selectedYear
+    (data) => data.year === selectedYear,
   );
 
   return (
@@ -296,15 +296,15 @@ export const AboutHistorySection = () => {
               </p>
 
               {/* 연도 목록 - 스크롤 가능 */}
-              <div className="flex flex-col gap-5 max-h-[400px] overflow-y-scroll pl-0 pr-2 items-start mt-4 custom-scrollbar">
+              <div className="flex w-28 mx-auto ml-20 flex-col gap-5 max-h-[400px] overflow-y-scroll pl-5 pr-45 items-center mt-4 custom-scrollbar">
                 {years.map((year) => (
                   <button
                     key={year}
                     onClick={() => setSelectedYear(year)}
-                    className="flex items-center gap-3 transition-colors"
+                    className="flex w-full items-center justify-center text-center gap-3 transition-colors"
                   >
                     <span
-                      className="font-bold"
+                      className="w-full font-bold text-center"
                       style={{
                         fontFamily: "var(--font-suit), SUIT, sans-serif",
                         color: selectedYear === year ? "#71787F" : "#B4B9BE",


### PR DESCRIPTION
# 변경점 👍
- 소개 페이지 상단 라벨 색상 변경 인터렉션을 구현하였습니다.
  - 현재 보고있는 섹션이 중앙에 위치하면, 상단 라벨이 회색 -> 오렌지색으로 변경됩니다.
- 이 외에도 기존에 pretendard로 잘못 들어가있던 폰트를 SUIT 폰트로 변경하였습니다.
- 안드로이드 직군 스터디 커리큘럼에 누락되었던 항목들을 채워넣었습니다.

# 스크린샷 🖼
<img width="1499" height="727" alt="image" src="https://github.com/user-attachments/assets/8caac27f-33a0-4bfe-8ef6-2ad62ba04d52" />
<img width="1489" height="736" alt="image" src="https://github.com/user-attachments/assets/c4249256-1351-46f8-99f5-c03d83de423b" />

close #22 
